### PR TITLE
add sdl2 dep

### DIFF
--- a/Formula/ffmpeg-encore.rb
+++ b/Formula/ffmpeg-encore.rb
@@ -26,6 +26,7 @@ class FfmpegEncore < Formula
   depends_on "libvmaf"
   depends_on "libvorbis"
   depends_on "libvpx"
+  depends_on "sdl2"
   depends_on "openssl"
   depends_on "x264-encore"
   depends_on "x265-encore"


### PR DESCRIPTION
Signed-off-by: Josef Andersson <josef.andersson@svt.se>

## Description

This adds the sdl2 dependency

Fixes #(1)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The bug was verified on a fresh install of brew and ffmpeg-encore on Ubuntu 20.04.

