### PR TITLE
feat: build and publish images with GitHub actions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,12 +5,13 @@ on:
     branches: 
       - master
       - main
-      - basicci
     tags:
       - 'v*'
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: avtools-debian
+  IMAGE_NAME_DIST: avtools-osadl-debian
+  IMAGE_NAME_SOURCE: avtools-osadl-debian-source
+  IMAGE_NAME: avtools-osadl-debian-non-dist
 
 jobs:
   
@@ -41,7 +42,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (tags, labels) for non distribution image 
         id: meta
         uses: docker/metadata-action@v3
         with:
@@ -53,15 +54,77 @@ jobs:
             type=ref,event=tag,priority=2
             type=raw,value=${{ env.IMAGE_NAME }}-{{branch}}-{{date 'YYYYMMDD'}}-{{sha}},priority=31,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=${{ env.IMAGE_NAME }}-{{tag}}-{{date 'YYYYMMDD'}}-{{sha}},priority=32, enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+      
+      - name: Build dependency layer for caching
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/Dockerfile.osadl.debian
+          cache-to: type=gha,mode=max
+          platforms: x86_64
+          push: false
+          target: dependencies
 
-      - name: Build and push Docker image
+      - name: Build and push non distribution Image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/Dockerfile.osadl.debian
+          cache-from: type=gha
+          platforms: x86_64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: distribution
+
+      - name: Extract metadata (tags, labels) for distribution image
+        id: metadist
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_DIST }}
+          flavor: |
+            latest=true
+          tags: |
+            type=raw,value={{branch}},priority=1,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
+            type=ref,event=tag,priority=2
+            type=raw,value=${{ env.IMAGE_NAME }}-{{branch}}-{{date 'YYYYMMDD'}}-{{sha}},priority=31,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ env.IMAGE_NAME }}-{{tag}}-{{date 'YYYYMMDD'}}-{{sha}},priority=32, enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+      
+      - name: Build and push distribution image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/Dockerfile.osadl.debian
+          cache-from: type=gha
+          platforms: x86_64
+          push: true
+          tags: ${{ steps.metadist.outputs.tags }}
+          build-args: |
+                  FFMPEG_BREW_OPTIONS=--without-fdk-aac
+          labels: ${{ steps.metadist.outputs.labels }}
+          target: distribution
+
+      - name: Extract metadata (tags, labels) for source image
+        id: metasource
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_SOURCE }}
+          flavor: |
+            latest=true
+          tags: |
+            type=raw,value={{branch}},priority=1,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
+            type=ref,event=tag,priority=2
+            type=raw,value=${{ env.IMAGE_NAME }}-{{branch}}-{{date 'YYYYMMDD'}}-{{sha}},priority=31,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ env.IMAGE_NAME }}-{{tag}}-{{date 'YYYYMMDD'}}-{{sha}},priority=32, enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+      
+      - name: Build and push source image
         uses: docker/build-push-action@v2
         with:
           context: .
           file: docker/Dockerfile.osadl.debian
           platforms: x86_64
-          no-cache: true
+          cache-from: type=gha
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
+          tags: ${{ steps.metasource.outputs.tags }}
+          labels: ${{ steps.metasource.outputs.labels }}
+          target: source

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -44,19 +44,19 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for non distribution image 
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=true
-          tags: |
-            type=raw,value={{branch}},priority=1,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
-            type=ref,event=tag,priority=2
-            type=raw,value=${{ env.IMAGE_NAME }}-{{branch}}-{{date 'YYYYMMDD'}}-{{sha}},priority=31,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=${{ env.IMAGE_NAME }}-{{tag}}-{{date 'YYYYMMDD'}}-{{sha}},priority=32, enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+# NOTE: until further, dont' build the non-dist
+#     - name: Extract metadata (tags, labels) for non distribution image 
+#       id: meta
+#       uses: docker/metadata-action@v3
+#       with:
+#         images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+#         flavor: |
+#           latest=true
+#         tags: |
+#           type=raw,value={{branch}},priority=1,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
+#           type=ref,event=tag,priority=2
+#           type=raw,value=${{ env.IMAGE_NAME }}-{{branch}}-{{date 'YYYYMMDD'}}-{{sha}},priority=31,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
+#           type=raw,value=${{ env.IMAGE_NAME }}-{{tag}}-{{date 'YYYYMMDD'}}-{{sha}},priority=32, enable=${{ startsWith(github.ref, 'refs/tags/v') }}
       
       - name: Build dependency layer for caching
         uses: docker/build-push-action@v2
@@ -68,17 +68,18 @@ jobs:
           push: false
           target: dependencies
 
-      - name: Build and push non distribution Image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: docker/Dockerfile.osadl.debian
-          cache-from: type=gha
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          target: distribution
+# NOTE: until further, dont' build the non-dist
+#     - name: Build and push non distribution Image
+#       uses: docker/build-push-action@v2
+#       with:
+#         context: .
+#         file: docker/Dockerfile.osadl.debian
+#         cache-from: type=gha
+#         platforms: linux/amd64,linux/arm64
+#         push: true
+#         tags: ${{ steps.meta.outputs.tags }}
+#         labels: ${{ steps.meta.outputs.labels }}
+#         target: distribution
 
       - name: Extract metadata (tags, labels) for distribution image
         id: metadist

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,7 +64,7 @@ jobs:
           context: .
           file: docker/Dockerfile.osadl.debian
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: false
           target: dependencies
 
@@ -101,7 +101,7 @@ jobs:
           file: docker/Dockerfile.osadl.debian
           cache-from: type=gha
           cache-to: type=gha,mode=min
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.metadist.outputs.tags }}
           build-args: |
@@ -127,7 +127,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.osadl.debian
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           cache-from: type=gha
           build-args: |
                   FFMPEG_BREW_OPTIONS=--without-fdk-aac

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -96,6 +96,7 @@ jobs:
           context: .
           file: docker/Dockerfile.osadl.debian
           cache-from: type=gha
+          cache-to: type=gha,mode=min
           platforms: x86_64
           push: true
           tags: ${{ steps.metadist.outputs.tags }}
@@ -124,6 +125,8 @@ jobs:
           file: docker/Dockerfile.osadl.debian
           platforms: x86_64
           cache-from: type=gha
+          build-args: |
+                  FFMPEG_BREW_OPTIONS=--without-fdk-aac
           push: true
           tags: ${{ steps.metasource.outputs.tags }}
           labels: ${{ steps.metasource.outputs.labels }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,10 +26,13 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-
+        
 
       - name: Inspect builder
         run: |
@@ -61,7 +64,7 @@ jobs:
           context: .
           file: docker/Dockerfile.osadl.debian
           cache-to: type=gha,mode=max
-          platforms: x86_64
+          platforms: linux/amd64,linux/arm64
           push: false
           target: dependencies
 
@@ -71,7 +74,7 @@ jobs:
           context: .
           file: docker/Dockerfile.osadl.debian
           cache-from: type=gha
-          platforms: x86_64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -97,7 +100,7 @@ jobs:
           file: docker/Dockerfile.osadl.debian
           cache-from: type=gha
           cache-to: type=gha,mode=min
-          platforms: x86_64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.metadist.outputs.tags }}
           build-args: |
@@ -123,7 +126,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.osadl.debian
-          platforms: x86_64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           build-args: |
                   FFMPEG_BREW_OPTIONS=--without-fdk-aac

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,67 @@
+name: Create and publish Docker images
+
+on:
+  push:
+    branches: 
+      - master
+      - main
+      - basicci
+    tags:
+      - 'v*'
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: avtools-debian
+
+jobs:
+  
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+        contents: read
+        packages: write
+
+    steps:
+      
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+
+      - name: Inspect builder
+        run: |
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=true
+          tags: |
+            type=raw,value={{branch}},priority=1,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
+            type=ref,event=tag,priority=2
+            type=raw,value=${{ env.IMAGE_NAME }}-{{branch}}-{{date 'YYYYMMDD'}}-{{sha}},priority=31,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ env.IMAGE_NAME }}-{{tag}}-{{date 'YYYYMMDD'}}-{{sha}},priority=32, enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/Dockerfile.osadl.debian
+          platforms: x86_64
+          no-cache: true
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -13,5 +13,14 @@ Files: *.adoc
 Copyright: 2021 Sveriges Television AB
 License: CC0-1.0
 
+Files: *motd*.txt
+Copyright: 2021 Sveriges Television AB
+License: CC0-1.0
 
+Files: .github/workflows/publish.yaml
+Copyright: 2021 Sveriges Television AB
+License: CC0-1.0
 
+Files: **/Dockerfile.osadl.debian
+Copyright: 2021 Sveriges Television AB
+License: CC0-1.0

--- a/Formula/ffmpeg-encore.rb
+++ b/Formula/ffmpeg-encore.rb
@@ -8,7 +8,7 @@ class FfmpegEncore < Formula
   homepage "https://ffmpeg.org/"
   url "https://ffmpeg.org/releases/ffmpeg-4.3.1.tar.xz"
   sha256 "ad009240d46e307b4e03a213a0f49c11b650e445b1f8be0dda2a9212b34d2ffb"
-  license "GPL-2.0-only"
+  license "GPL-3.0-or-later"
   revision 1
   head "https://github.com/FFmpeg/FFmpeg.git"
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,30 @@ Currently this tap holds minor modifications of existing core Homebrew formulas 
 
 ## Installation & Usage
 
+There are a few options. 
+
+You can use the prebuilt docker-image, build your own docker image or add the Brew tap.
+
+### Docker
+
+You can use the prebuilt Docker image or build your own.
+
+The prebuilt Docker image is available at [avtools-debian]() 
+
+### Building your own Dockerimage
+
+You can also build you own Docker Image using the included Dockerfile
+
+_Example, in root, using buildx, building for the linux/amd64 platform_
+
+```console
+$ docker buildx build --platform linux/amd64 . -f docker/Dockerfile.oasdl.debian
+```
+ 
+
+
+### Install Brew tap
+
 - Add the tap to your Brew tap configuration, and install the tools you wish
 
 ```console
@@ -39,14 +63,18 @@ Currently, the configurations options are few - this might change in the future.
 
 ## Known issues
 
-Auditing the Formulas still gives a few warnings, *feel free to fix them.*
+* The Docker Images could be smaller if it used Alpine, and was optimized regarding dependencies
+
+* The build uses some libraries installed through Apt, so we are *not* in the Brew eco system totally - in other words, all dependecies used for the avvideo tools are not found in Brews. Run ffmpeg with ldd to see a list.
+ 
+* Auditing the Formulas still gives a few warnings, *feel free to fix them.*
 To audit them all, from the project's root folder you can run
 
 ```console
 $ for f in Formula/*.rb; do echo "Processing $f file.."; eval "brew audit --new --formula $f"; done
 ```
 
-The Formulas is not yet keg_only, which could allow to have multiple instances/versions
+* The Formulas is not yet keg_only, which could allow to have multiple instances/versions
 
 ## Getting help
 
@@ -64,7 +92,13 @@ See [CONTRIBUTING](CONTRIBUTING.adoc)
 
 - The Formulas FFmpeg-encore, x264-encore, x264-encore is built on Brew formulas, released under the same BSD-2 License, but also Copyright 2009-present, Homebrew contributors besides SVT.
 
-- However, Note that the binaries the Formulas will *build* is released under various other licenses, see the different projects homepages and the license metadata in the Formula for some guidance for making an informed decision if you intend to share any built binaries further.
+- However, Note that the binaries the Formulas will *build* is released under various other licenses, see the different projects homepages and the license metadata in the Formula for some guidance for making an informed decision if you intend to share any built binaries further, if you add things.
+
+The Docker Image avtools-debian image is built on the [OSADL](https://www.osadl.org/OSADL-Docker-Base-Image.osadl-docker-base-image.0.html ) Debian image, wich contains license information and source code, see information.
+
+- The FFmpeg binary compiled in avtools-ubuntu is enabling gpl and using third party libraries:
+  - 264, 265 GPL (TODO).
+
 
 ----
 
@@ -74,5 +108,5 @@ See [CONTRIBUTING](CONTRIBUTING.adoc)
 
 ## Credits and references
 
-To the great projects FFmpeg, Brew, x264, x265 and many others we forgot.
+To the great projects OSADL, FFmpeg, Brew, x264, x265 and many others we forgot.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ brew install ffmpeg-encore
 
 #### Test the pre-built Docker Image
 
-_**This image is only intended for development and not production usage. It contains the taps version of FFmpeg. 
+_**This image is only intended for development and certainly not for production usage. It contains the taps version of the avtools formulas, and a few other apps like mediainfo.
 Notably, compared to the Formula/ffmpeg-encore does *excludes* the GPL-incompatible library fdk-aac** (but use aac instedI)_
 
 [avtools-osadl-debian](https://github.com/svt?tab=packages&repo_name=homebrew-avtools), 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![REUSE Compliance](https://img.shields.io/reuse/compliance/github.com/janderssonse/homebrew-avtools)
+![REUSE Compliance](https://img.shields.io/reuse/compliance/github.com/svt/homebrew-avtools)
 
 # Homebrew AVTools
 
@@ -51,7 +51,7 @@ $ brew install ffmpeg-encore
 _**This image is only intended for development and not production usage. It contains the taps version of FFmpeg. 
 Notably, compared to the Formula/ffmpeg-encore does *excludes* the GPL-incompatible library fdk-aac** (but use aac instedI)_
 
-[avtools-osadl-debian](https://github.com/janderssonse?tab=packages&repo_name=homebrew-avtools), 
+[avtools-osadl-debian](https://github.com/svt?tab=packages&repo_name=homebrew-avtools), 
 
 
 #### Building your own Dockerimage
@@ -131,7 +131,7 @@ The Docker Image avtools-osadl-debian image is built on the [OSADL](https://www.
 
 The FFmpeg binary compiled in avtools-osadl-debian is released as under GPLv3 due to being the least common distrubutable license combination. 
 
-A corresponding image [avtools-osadl-debian-source-image](https://github.com/janderssonse?tab=packages&repo_name=homebrew-avtools) contains corresponding source and license information for the libraries used.
+A corresponding image [avtools-osadl-debian-source-image](https://github.com/svt?tab=packages&repo_name=homebrew-avtools) contains corresponding source and license information for the libraries used.
 
 _We aim to follow best practices for license compliance, however, if you find something we missed or even plain errors, please let us know so that we can improve this as soon as possible._
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
+![REUSE Compliance](https://img.shields.io/reuse/compliance/github.com/janderssonse/homebrew-avtools)
+
 # Homebrew AVTools
 
 A brew tap for assorted audio and video tools in use at SVT, mainly for encoding purposes.
-Currently this tap holds minor modifications of existing core Homebrew formulas  - ffmpeg and codecs, but also formulas for a few of the [FFmpeg filters released by SVT](https://github.com/svt/ffmpeg-filter-proxy)
+
+Currently this tap holds minor modifications of existing core Homebrew formulas  - FFmpeg and codecs, but also formulas for a few of the [FFmpeg filters released by SVT](https://github.com/svt/ffmpeg-filter-proxy)
 
 * ffmpeg-encore - FFmpeg tailored for encore, with x264, x265, [ffmpg-filter-proxy support](https://github.com/svt/ffmpeg-filter-proxy)
 * libsrf-proxy-filter -  [Subtitle Rendering Format filter](https://github.com/svt/ffmpeg-filter-proxy-filters)
 * libsvg-proxy-filter - [SVG filter](https://github.com/svt/ffmpeg-filter-proxy-filters)
 * x264-encore - [x264 encoder lib](https://code.videolan.org/videolan/x264.git)
 * x265-encore - [x265 encoder lib](https://bitbucket.org/multicoreware/x265_git)
+
 
 ## Dependencies
 
@@ -17,24 +21,7 @@ Currently this tap holds minor modifications of existing core Homebrew formulas 
 
 There are a few options. 
 
-You can use the prebuilt docker-image, build your own docker image or add the Brew tap.
-
-### Docker
-
-You can use the prebuilt Docker image or build your own.
-
-The prebuilt Docker image is available at [avtools-debian]() 
-
-### Building your own Dockerimage
-
-You can also build you own Docker Image using the included Dockerfile
-
-_Example, in root, using buildx, building for the linux/amd64 platform_
-
-```console
-$ docker buildx build --platform linux/amd64 . -f docker/Dockerfile.oasdl.debian
-```
- 
+You can use the pre-built Docker Image, build your own Docker Image from the Dockerfile, or add the Brew tap and build it on your machine.
 
 
 ### Install Brew tap
@@ -57,6 +44,45 @@ $ brew tap-info svt/avtools --json | jq
 $ brew install ffmpeg-encore
 ```
 
+### With Docker
+
+#### Test the pre-built Docker Image
+
+_**This image is only intended for development and not production usage. It contains the taps version of FFmpeg. 
+Notably, compared to the Formula/ffmpeg-encore does *excludes* the GPL-incompatible library fdk-aac** (but use aac instedI)_
+
+[avtools-osadl-debian](https://github.com/janderssonse?tab=packages&repo_name=homebrew-avtools), 
+
+
+#### Building your own Dockerimage
+
+
+You can also build you own Docker Image using the included Dockerfile. 
+
+Use of [Docker buildx](https://docs.docker.com/buildx/working-with-buildx/) is assumed
+
+_Example, located in the project root, using buildx, building the distribution image for the linux/amd64 platform, without the fdk-aac library_
+
+```console
+$ docker build --target=distribution --platform linux/amd64 --build-arg=FFMPEG_BREW_OPTIONS=--without-fdk-aac . -f docker/Dockerfile.osadl.debian
+```
+
+Available build targets are:
+
+* buildimage
+* distribution
+* source
+
+Default: If you dont give a --target you will build the distribution image as default - but also all other targets, so set the target, you want to avoid the source target if you don't need it.
+
+Brew Options through the Docker build:
+
+* To build the FFmepg forumla without fdk-aac you could pass the --build-arg FFMPEG_BREW_OPTIONS=--without-fdk-aac
+
+
+**NOTE: If you build your own Docker Image for anything else than internal use, you have to consider how the third party dependencies interact, if you want to avoid building an un-distributable image.
+A notable example is that you can't include the fdk-aac library together with x264,x265 in the same build, as the fdk-aac license is currently GPL-incompatible.**
+
 ## Configuration
 
 Currently, the configurations options are few - this might change in the future.
@@ -65,7 +91,7 @@ Currently, the configurations options are few - this might change in the future.
 
 * The Docker Images could be smaller if it used Alpine, and was optimized regarding dependencies
 
-* The build uses some libraries installed through Apt, so we are *not* in the Brew eco system totally - in other words, all dependecies used for the avvideo tools are not found in Brews. Run ffmpeg with ldd to see a list.
+* The build uses some libraries installed through apt, so we are *not* in the Brew eco system totally - in other words, all dependecies used for the avvideo tools are not found in Brew repos, most notably glibc. Run ffmpeg with ldd to see a list.
  
 * Auditing the Formulas still gives a few warnings, *feel free to fix them.*
 To audit them all, from the project's root folder you can run
@@ -88,17 +114,26 @@ See [CONTRIBUTING](CONTRIBUTING.adoc)
 
 ## License
 
+### FORMULAS
+
 - The Formulas in this project is all released under the [BSD 2-clause "Simplified" License](LICENSE)
 
-- The Formulas FFmpeg-encore, x264-encore, x264-encore is built on Brew formulas, released under the same BSD-2 License, but also Copyright 2009-present, Homebrew contributors besides SVT.
+- The Formulas FFmpeg-encore, x264-encore, x264-encore is built on Brew formulas, formulas themselves released under the same BSD-2 License, but also Copyright 2009-present, Homebrew contributors besides SVT.
 
-- However, Note that the binaries the Formulas will *build* is released under various other licenses, see the different projects homepages and the license metadata in the Formula for some guidance for making an informed decision if you intend to share any built binaries further, if you add things.
+### NOTE ABOUT THE FFMPEG FORMULA BUILD BINARY RESULTS
 
-The Docker Image avtools-debian image is built on the [OSADL](https://www.osadl.org/OSADL-Docker-Base-Image.osadl-docker-base-image.0.html ) Debian image, wich contains license information and source code, see information.
+The binaries the Formulas will *build* is released under various other licenses, depending on your build options. 
+See the different projects homepages and the license metadata in the docker/misc/LICENSE_THIRD_PARTIES.txt for some guidance to make an informed decision if you intend to distribute any built binaries further. 
 
-- The FFmpeg binary compiled in avtools-ubuntu is enabling gpl and using third party libraries:
-  - 264, 265 GPL (TODO).
+### PRE-BUILT DOCKER IMAGE LICENSE
 
+The Docker Image avtools-osadl-debian image is built on the [OSADL](https://www.osadl.org/OSADL-Docker-Base-Image.osadl-docker-base-image.0.html ) Debian base image.
+
+The FFmpeg binary compiled in avtools-osadl-debian is released as under GPLv3 due to being the least common distrubutable license combination. 
+
+A corresponding image [avtools-osadl-debian-source-image](https://github.com/janderssonse?tab=packages&repo_name=homebrew-avtools) contains corresponding source and license information for the libraries used.
+
+_We aim to follow best practices for license compliance, however, if you find something we missed or even plain errors, please let us know so that we can improve this as soon as possible._
 
 ----
 
@@ -108,5 +143,5 @@ The Docker Image avtools-debian image is built on the [OSADL](https://www.osadl.
 
 ## Credits and references
 
-To the great projects OSADL, FFmpeg, Brew, x264, x265 and many others we forgot.
+To many to mention, the list would be endless here, but a sincerly thanks to projects big or small making this repo possible.
 

--- a/docker/Dockerfile.osadl.debian
+++ b/docker/Dockerfile.osadl.debian
@@ -27,12 +27,15 @@ ARG APT_BUILD_DEPS="autoconf \
 	       ca-certificates \
 	       zip \
 	       unzip "
+
 ARG DOCKER_BASE=osadl/debian-docker-base-image:bullseye-amd64-211011
+ARG REPO_OWNER=janderssonse
 
 #General dependency image - to simplify caching
 FROM ${DOCKER_BASE} as dependencies
 
 ARG APT_BUILD_DEPS
+ARG REPO_OWNER
 
 RUN     apt-get update --allow-releaseinfo-change && apt upgrade && \ 
         apt-get install -yq --no-install-recommends $APT_BUILD_DEPS && \
@@ -45,7 +48,7 @@ RUN export HOMEBREW_NO_AUTO_UPDATE=1 && \
     export HOMEBREW_NO_ANALYTICS=1 && \
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" && \
     brew install gcc mediainfo && \
-    brew tap janderssonse/avtools && \
+    brew tap $REPO_OWNER/avtools && \
     brew install --only-dependencies ffmpeg-encore libsvg-proxy-filter libsrf-proxy-filter
 
 #Basebuild image for ffmpeg option variations 
@@ -79,8 +82,10 @@ RUN rm -rf /home/linuxbrew/.linuxbrew/Homebrew
 #distribution image
 FROM  ${DOCKER_BASE} as distribution
 
-LABEL org.opencontainers.image.url="https://github.com/janderssonse/homebrew-avtools"
-LABEL org.opencontainers.image.source="https://github.com/janderssonse/homebrew-avtools"
+ARG REPO_OWNER
+
+LABEL org.opencontainers.image.url="https://github.com/$REPO_OWNER/homebrew-avtools"
+LABEL org.opencontainers.image.source="https://github.com/$REPO_OWNER/homebrew-avtools"
 LABEL org.opencontainers.image.title="avtools-osadl-debian-distribution"
  
 # brew issue, the avtools-tap formulas for ffmpeg and mediainfo uses some host system libraries instead of 100% brew -> slight host dependency instead of brew dep. If brew updates the glibc version this most likely be discarded, at least most parts of it. 
@@ -116,8 +121,10 @@ CMD ["ffmpeg", "-version"]
 #source Image
 FROM ${DOCKER_BASE} as source
 
-LABEL org.opencontainers.image.url="https://github.com/janderssonse/homebrew-avtools"
-LABEL org.opencontainers.image.source="https://github.com/janderssonse/homebrew-avtools"
+ARG REPO_OWNER
+
+LABEL org.opencontainers.image.url="https://github.com/$REPO_OWNER/homebrew-avtools"
+LABEL org.opencontainers.image.source="https://github.com/$REPO_OWNER/homebrew-avtools"
 LABEL org.opencontainers.image.title="avtools-osadl-debian-source"
 
 ARG APT_BUILD_DEPS

--- a/docker/Dockerfile.osadl.debian
+++ b/docker/Dockerfile.osadl.debian
@@ -1,0 +1,147 @@
+ARG APT_BUILD_DEPS="autoconf \
+               automake \
+               cmake \
+               curl \
+               bzip2 \
+               libexpat1-dev \
+               g++ \
+               git \
+               gperf \
+               libtool \
+               make \
+               meson \
+               nasm \
+               perl \
+               pkg-config \
+               python \
+               libssl-dev \
+               yasm \
+               zlib1g-dev \
+               build-essential \
+	       sudo \
+	       file \
+	       locales \
+	       ruby \
+	       git \
+	       expect \
+	       openssh-client  \
+	       ca-certificates \
+	       zip \
+	       unzip "
+
+
+#General dependency image - to simplify caching
+FROM osadl/debian-docker-base-image:buster_amd64_v1.2 as dependencies
+
+ARG APT_BUILD_DEPS
+
+RUN     apt-get update --allow-releaseinfo-change && \ 
+        apt-get install -yq --no-install-recommends $APT_BUILD_DEPS && \
+	apt-get clean && apt-get autoremove
+	
+
+ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH
+
+RUN export HOMEBREW_NO_AUTO_UPDATE=1 && \ 
+    export HOMEBREW_NO_ANALYTICS=1 && \
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" && \
+    brew install gcc mediainfo && \
+    brew tap janderssonse/avtools && \
+    brew install --only-dependencies ffmpeg-encore libsvg-proxy-filter libsrf-proxy-filter
+
+#Basebuild image for ffmpeg option variations 
+FROM dependencies as buildimage
+
+ARG FFMPEG_BREW_OPTIONS
+
+ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH
+
+# Install SVT's ffmpeg (with SVT filters) and mediainfo through the SVT brew repo
+RUN mkdir -m777 /ffmpeg-filters && \
+    brew install ffmpeg-encore $FFMPEG_BREW_OPTIONS && \
+    brew install libsvg-proxy-filter libsrf-proxy-filter && \
+    cp $(brew --prefix)/lib/libsvg_filter.so $(brew --prefix)/lib/libsrf_filter.so /ffmpeg-filters/ && \
+    brew autoremove && \
+    brew cleanup -s && \
+    rm -rf "$(brew --cache)"
+
+CMD ["ffmpeg", "-version"]
+
+#A trim stage. You can most likely refine this stage
+FROM osadl/debian-docker-base-image:buster_amd64_v1.2 as cleanupfordistribution
+
+COPY --from=buildimage /ffmpeg-filters /ffmpeg-filters
+COPY --from=buildimage /home/linuxbrew/.linuxbrew /home/linuxbrew/.linuxbrew
+COPY --from=buildimage /lib/x86_64-linux-gnu /lib/x86_64-linux-gnu
+
+RUN rm -rf /home/linuxbrew/.linuxbrew/Homebrew && \
+    rm /buster-src_1.2.tgz
+
+
+#distribution image
+FROM osadl/debian-docker-base-image:buster_amd64_v1.2 as distribution
+
+LABEL org.opencontainers.image.url="https://github.com/janderssonse/homebrew-avtools"
+LABEL org.opencontainers.image.source="https://github.com/janderssonse/homebrew-avtools"
+LABEL org.opencontainers.image.title="avtools-osadl-debian-distribution"
+
+RUN useradd -ms /bin/bash avtools
+
+COPY docker/misc/motd.dist.txt /etc/motd
+COPY docker/misc/LICENSE-THIRD-PARTY.txt /
+
+COPY --from=cleanupfordistribution --chown=avtools:avtools /ffmpeg-filters /ffmpeg-filters
+COPY --from=cleanupfordistribution --chown=avtools:avtools /home/linuxbrew/.linuxbrew /home/linuxbrew/.linuxbrew
+
+# brew issue, the avtools-tap formulas for ffmpeg and mediainfo uses some host system libraries instead of 100% brew -> slight host dependency instead of brew dep. If brew updates the glibc version this most likely be discarded, at least most parts of it. 
+COPY --from=buildimage /lib/x86_64-linux-gnu/libc.so.6 \
+	/lib/x86_64-linux-gnu/libm.so.6 \
+	/lib/x86_64-linux-gnu/libpthread.so.0 \
+	/lib/x86_64-linux-gnu/libdl.so.2 \
+	/lib/x86_64-linux-gnu/libresolv.so.2 \
+	/lib/x86_64-linux-gnu/
+
+USER avtools
+WORKDIR /home/avtools/
+
+ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH
+
+CMD ["ffmpeg", "-version"]
+
+#source Image
+FROM osadl/debian-docker-base-image:buster_amd64_v1.2 as source
+
+LABEL org.opencontainers.image.url="https://github.com/janderssonse/homebrew-avtools"
+LABEL org.opencontainers.image.source="https://github.com/janderssonse/homebrew-avtools"
+LABEL org.opencontainers.image.title="avtools-osadl-debian-source"
+
+ARG APT_BUILD_DEPS
+
+ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH
+
+COPY --from=buildimage /home/linuxbrew/.linuxbrew /home/linuxbrew/.linuxbrew
+
+#Brew and apt sources to tar
+RUN sourceDir="/source" && \
+  aptSourceDir="/tmp/aptsources" && \
+  brewSourceDir="/tmp/brewsources" && \ 
+  mkdir ${brewSourceDir} && \
+  mkdir ${aptSourceDir} && \
+  mkdir ${sourceDir} && \
+  export HOMEBREW_NO_AUTO_UPDATE=1 && export HOMEBREW_NO_ANALYTICS=1 && \
+  apt-get update --allow-releaseinfo-change && \ 
+  apt-get install -yq --no-install-recommends bzip2 ca-certificates curl git && \
+  brew unpack $(brew list --formula) --destdir ${brewSourceDir} && \
+  cd ${aptSourceDir} && apt --download-only source $APT_BUILD_DEPS && \
+  echo "Will  tar brew src" && \
+  XZ_OPT='-T0 -9' tar --xz -cf "${sourceDir}/brew-src_$(date '+%Y-%m-%d').tar.xz" -C ${brewSourceDir} . && \
+  echo "Will tar apt src" && \
+  XZ_OPT='-T0 -9' tar --xz -cf "${sourceDir}/apt-src_$(date '+%Y-%m-%d').tar.xz" -C ${aptSourceDir} . && \
+  rm -rf ${brewSourceDir} && \
+  apt-get clean && apt-get autoremove
+
+
+COPY docker/misc/motd.source.txt /etc/motd
+
+# the default (if no target was given on build )
+FROM distribution

--- a/docker/Dockerfile.osadl.debian
+++ b/docker/Dockerfile.osadl.debian
@@ -13,7 +13,6 @@ ARG APT_BUILD_DEPS="autoconf \
                nasm \
                perl \
                pkg-config \
-               python \
                libssl-dev \
                yasm \
                zlib1g-dev \
@@ -28,10 +27,10 @@ ARG APT_BUILD_DEPS="autoconf \
 	       ca-certificates \
 	       zip \
 	       unzip "
-
+ARG DOCKER_BASE=osadl/debian-docker-base-image:bullseye-amd64-211011
 
 #General dependency image - to simplify caching
-FROM osadl/debian-docker-base-image:buster_amd64_v1.2 as dependencies
+FROM ${DOCKER_BASE} as dependencies
 
 ARG APT_BUILD_DEPS
 
@@ -68,18 +67,17 @@ RUN mkdir -m777 /ffmpeg-filters && \
 CMD ["ffmpeg", "-version"]
 
 #A trim stage. You can most likely refine this stage
-FROM osadl/debian-docker-base-image:buster_amd64_v1.2 as cleanupfordistribution
+FROM ${DOCKER_BASE} as cleanupfordistribution
 
 COPY --from=buildimage /ffmpeg-filters /ffmpeg-filters
 COPY --from=buildimage /home/linuxbrew/.linuxbrew /home/linuxbrew/.linuxbrew
 COPY --from=buildimage /lib/x86_64-linux-gnu /lib/x86_64-linux-gnu
 
-RUN rm -rf /home/linuxbrew/.linuxbrew/Homebrew && \
-    rm /buster-src_1.2.tgz
+RUN rm -rf /home/linuxbrew/.linuxbrew/Homebrew 
 
 
 #distribution image
-FROM osadl/debian-docker-base-image:buster_amd64_v1.2 as distribution
+FROM  ${DOCKER_BASE} as distribution
 
 LABEL org.opencontainers.image.url="https://github.com/janderssonse/homebrew-avtools"
 LABEL org.opencontainers.image.source="https://github.com/janderssonse/homebrew-avtools"
@@ -109,7 +107,7 @@ ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH
 CMD ["ffmpeg", "-version"]
 
 #source Image
-FROM osadl/debian-docker-base-image:buster_amd64_v1.2 as source
+FROM ${DOCKER_BASE} as source
 
 LABEL org.opencontainers.image.url="https://github.com/janderssonse/homebrew-avtools"
 LABEL org.opencontainers.image.source="https://github.com/janderssonse/homebrew-avtools"
@@ -132,7 +130,7 @@ RUN sourceDir="/source" && \
   apt-get update --allow-releaseinfo-change && \ 
   apt-get install -yq --no-install-recommends bzip2 ca-certificates curl git && \
   brew unpack $(brew list --formula) --destdir ${brewSourceDir} && \
-  cd ${aptSourceDir} && apt --download-only source $APT_BUILD_DEPS && \
+  cd ${aptSourceDir} && apt-get update && apt-get --download-only source $APT_BUILD_DEPS && \
   echo "Will  tar brew src" && \
   XZ_OPT='-T0 -9' tar --xz -cf "${sourceDir}/brew-src_$(date '+%Y-%m-%d').tar.xz" -C ${brewSourceDir} . && \
   echo "Will tar apt src" && \

--- a/docker/Dockerfile.osadl.debian
+++ b/docker/Dockerfile.osadl.debian
@@ -34,7 +34,7 @@ FROM ${DOCKER_BASE} as dependencies
 
 ARG APT_BUILD_DEPS
 
-RUN     apt-get update --allow-releaseinfo-change && \ 
+RUN     apt-get update --allow-releaseinfo-change && apt upgrade && \ 
         apt-get install -yq --no-install-recommends $APT_BUILD_DEPS && \
 	apt-get clean && apt-get autoremove
 	
@@ -82,8 +82,20 @@ FROM  ${DOCKER_BASE} as distribution
 LABEL org.opencontainers.image.url="https://github.com/janderssonse/homebrew-avtools"
 LABEL org.opencontainers.image.source="https://github.com/janderssonse/homebrew-avtools"
 LABEL org.opencontainers.image.title="avtools-osadl-debian-distribution"
+ 
+# brew issue, the avtools-tap formulas for ffmpeg and mediainfo uses some host system libraries instead of 100% brew -> slight host dependency instead of brew dep. If brew updates the glibc version this most likely be discarded, at least most parts of it. 
+#COPY --from=buildimage /lib/x86_64-linux-gnu/libc.so.6 \
+########/lib/x86_64-linux-gnu/libm.so.6 \
+########/lib/x86_64-linux-gnu/libpthread.so.0 \
+########/lib/x86_64-linux-gnu/libdl.so.2 \
+########/lib/x86_64-linux-gnu/libresolv.so.2 \
+########/lib/x86_64-linux-gnu/
 
-RUN useradd -ms /bin/bash avtools
+
+RUN useradd -ms /bin/bash avtools && \
+    apt-get update --allow-releaseinfo-change && apt upgrade && \ 
+    apt-get install -yq --no-install-recommends libc6 && \
+    apt-get clean && apt-get autoremove
 
 COPY docker/misc/motd.dist.txt /etc/motd
 COPY docker/misc/LICENSE-THIRD-PARTY.txt /
@@ -91,13 +103,8 @@ COPY docker/misc/LICENSE-THIRD-PARTY.txt /
 COPY --from=cleanupfordistribution --chown=avtools:avtools /ffmpeg-filters /ffmpeg-filters
 COPY --from=cleanupfordistribution --chown=avtools:avtools /home/linuxbrew/.linuxbrew /home/linuxbrew/.linuxbrew
 
-# brew issue, the avtools-tap formulas for ffmpeg and mediainfo uses some host system libraries instead of 100% brew -> slight host dependency instead of brew dep. If brew updates the glibc version this most likely be discarded, at least most parts of it. 
-COPY --from=buildimage /lib/x86_64-linux-gnu/libc.so.6 \
-	/lib/x86_64-linux-gnu/libm.so.6 \
-	/lib/x86_64-linux-gnu/libpthread.so.0 \
-	/lib/x86_64-linux-gnu/libdl.so.2 \
-	/lib/x86_64-linux-gnu/libresolv.so.2 \
-	/lib/x86_64-linux-gnu/
+
+
 
 USER avtools
 WORKDIR /home/avtools/
@@ -130,7 +137,7 @@ RUN sourceDir="/source" && \
   apt-get update --allow-releaseinfo-change && \ 
   apt-get install -yq --no-install-recommends bzip2 ca-certificates curl git && \
   brew unpack $(brew list --formula) --destdir ${brewSourceDir} && \
-  cd ${aptSourceDir} && apt-get update && apt-get --download-only source $APT_BUILD_DEPS && \
+  cd ${aptSourceDir} && apt-get update && apt-get upgrade && apt-get --download-only source $APT_BUILD_DEPS && \
   echo "Will  tar brew src" && \
   XZ_OPT='-T0 -9' tar --xz -cf "${sourceDir}/brew-src_$(date '+%Y-%m-%d').tar.xz" -C ${brewSourceDir} . && \
   echo "Will tar apt src" && \

--- a/docker/Dockerfile.osadl.debian
+++ b/docker/Dockerfile.osadl.debian
@@ -31,7 +31,7 @@ ARG APT_BUILD_DEPS="autoconf \
 ARG DOCKER_BASE=osadl/debian-docker-base-image:bullseye-amd64-211011
 ARG REPO_OWNER=svt
 
-#General dependency image - to simplify caching
+#General dependency image - to simplify caching.
 FROM ${DOCKER_BASE} as dependencies
 
 ARG APT_BUILD_DEPS
@@ -51,7 +51,7 @@ RUN export HOMEBREW_NO_AUTO_UPDATE=1 && \
     brew tap $REPO_OWNER/avtools && \
     brew install --only-dependencies ffmpeg-encore libsvg-proxy-filter libsrf-proxy-filter
 
-#Basebuild image for ffmpeg option variations 
+#Basebuild image, from dependecies for ffmpeg option variations 
 FROM dependencies as buildimage
 
 ARG FFMPEG_BREW_OPTIONS
@@ -65,22 +65,18 @@ RUN mkdir -m777 /ffmpeg-filters && \
     cp $(brew --prefix)/lib/libsvg_filter.so $(brew --prefix)/lib/libsrf_filter.so /ffmpeg-filters/ && \
     brew autoremove && \
     brew cleanup -s && \
-    rm -rf "$(brew --cache)"
+    rm -rf "$(brew --cache)" 
 
 CMD ["ffmpeg", "-version"]
 
-#A trim stage. You can most likely refine this stage
-FROM ${DOCKER_BASE} as cleanupfordistribution
-
-COPY --from=buildimage /ffmpeg-filters /ffmpeg-filters
-COPY --from=buildimage /home/linuxbrew/.linuxbrew /home/linuxbrew/.linuxbrew
-COPY --from=buildimage /lib/x86_64-linux-gnu /lib/x86_64-linux-gnu
+#trim 
+FROM buildimage as trimimage
 
 RUN rm -rf /home/linuxbrew/.linuxbrew/Homebrew 
 
 
 #distribution image
-FROM  ${DOCKER_BASE} as distribution
+FROM ${DOCKER_BASE} as distribution
 
 ARG REPO_OWNER
 
@@ -89,13 +85,6 @@ LABEL org.opencontainers.image.source="https://github.com/$REPO_OWNER/homebrew-a
 LABEL org.opencontainers.image.title="avtools-osadl-debian-distribution"
  
 # brew issue, the avtools-tap formulas for ffmpeg and mediainfo uses some host system libraries instead of 100% brew -> slight host dependency instead of brew dep. If brew updates the glibc version this most likely be discarded, at least most parts of it. 
-#COPY --from=buildimage /lib/x86_64-linux-gnu/libc.so.6 \
-########/lib/x86_64-linux-gnu/libm.so.6 \
-########/lib/x86_64-linux-gnu/libpthread.so.0 \
-########/lib/x86_64-linux-gnu/libdl.so.2 \
-########/lib/x86_64-linux-gnu/libresolv.so.2 \
-########/lib/x86_64-linux-gnu/
-
 
 RUN useradd -ms /bin/bash avtools && \
     apt-get update --allow-releaseinfo-change && apt upgrade && \ 
@@ -105,10 +94,8 @@ RUN useradd -ms /bin/bash avtools && \
 COPY docker/misc/motd.dist.txt /etc/motd
 COPY docker/misc/LICENSE-THIRD-PARTY.txt /
 
-COPY --from=cleanupfordistribution --chown=avtools:avtools /ffmpeg-filters /ffmpeg-filters
-COPY --from=cleanupfordistribution --chown=avtools:avtools /home/linuxbrew/.linuxbrew /home/linuxbrew/.linuxbrew
-
-
+COPY --from=trimimage --chown=avtools:avtools /ffmpeg-filters /ffmpeg-filters
+COPY --from=trimimage --chown=avtools:avtools /home/linuxbrew/.linuxbrew /home/linuxbrew/.linuxbrew
 
 
 USER avtools
@@ -118,20 +105,15 @@ ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH
 
 CMD ["ffmpeg", "-version"]
 
-#source Image
-FROM ${DOCKER_BASE} as source
-
-ARG REPO_OWNER
-
-LABEL org.opencontainers.image.url="https://github.com/$REPO_OWNER/homebrew-avtools"
-LABEL org.opencontainers.image.source="https://github.com/$REPO_OWNER/homebrew-avtools"
-LABEL org.opencontainers.image.title="avtools-osadl-debian-source"
+#gather source that was added
+FROM ${DOCKER_BASE} as gathersource
 
 ARG APT_BUILD_DEPS
 
-ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH
 
 COPY --from=buildimage /home/linuxbrew/.linuxbrew /home/linuxbrew/.linuxbrew
+
+ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH
 
 #Brew and apt sources to tar
 RUN sourceDir="/source" && \
@@ -150,10 +132,24 @@ RUN sourceDir="/source" && \
   echo "Will tar apt src" && \
   XZ_OPT='-T0 -9' tar --xz -cf "${sourceDir}/apt-src_$(date '+%Y-%m-%d').tar.xz" -C ${aptSourceDir} . && \
   rm -rf ${brewSourceDir} && \
+  rm -rf ${aptSourceDir} && \
   apt-get clean && apt-get autoremove
 
 
 COPY docker/misc/motd.source.txt /etc/motd
 
-# the default (if no target was given on build )
+#build source
+FROM ${DOCKER_BASE} as source
+
+ARG REPO_OWNER
+
+LABEL org.opencontainers.image.url="https://github.com/$REPO_OWNER/homebrew-avtools"
+LABEL org.opencontainers.image.source="https://github.com/$REPO_OWNER/homebrew-avtools"
+LABEL org.opencontainers.image.title="avtools-osadl-debian-source"
+
+COPY --from=gathersource /source /source
+COPY docker/misc/motd.source.txt /etc/motd
+
+
+# the default build (if no target was given on build )
 FROM distribution

--- a/docker/Dockerfile.osadl.debian
+++ b/docker/Dockerfile.osadl.debian
@@ -29,7 +29,7 @@ ARG APT_BUILD_DEPS="autoconf \
 	       unzip "
 
 ARG DOCKER_BASE=osadl/debian-docker-base-image:bullseye-amd64-211011
-ARG REPO_OWNER=janderssonse
+ARG REPO_OWNER=svt
 
 #General dependency image - to simplify caching
 FROM ${DOCKER_BASE} as dependencies

--- a/docker/misc/LICENSE-THIRD-PARTY.txt
+++ b/docker/misc/LICENSE-THIRD-PARTY.txt
@@ -2782,4 +2782,6 @@ Am Wolfsmantel 33
 
 www.iis.fraunhofer.de/amm
 amm-info@iis.fraunhofer.de
-
+-------------------------------------------------------------------------------------
+NOTE: The current FDK-AAC license is not GPLxx compatible, and not included in these distribution builds, 
+ don't distrubute a build with this and GPL libraries. Included in the file anyway for completeness should you experiment with that build option.

--- a/docker/misc/LICENSE-THIRD-PARTY.txt
+++ b/docker/misc/LICENSE-THIRD-PARTY.txt
@@ -1,0 +1,2785 @@
+The AVTools distribution of FFmpeg uses the following libraries. 
+NOTE: FDK-AAC is notably not included in any AVTools distribution (as it is not GPL-compatible) but as it is refered to in the build recipe as an option, the license is included here too.
+
+-----------------------------------------------------------------------------
+Project: nasm
+License: BSD-2-Clause https://github.com/netwide-assembler/nasm/blob/master/LICENSE
+Repo: https://github.com/netwide-assembler/nasm
+-----------------------------------------------------------------------------
+
+NASM is now licensed under the 2-clause BSD license, also known as the
+simplified BSD license.
+
+    Copyright 1996-2010 the NASM Authors - All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following
+    conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+      
+      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+      CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+      INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+      MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+      DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+      CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+      SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+      NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+      LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+      HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+      CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+      OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+      EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+Project: x264
+License: GPL-2.0-or-later https://code.videolan.org/videolan/x264/-/raw/master/COPYING
+Repo: https://code.videolan.org/videolan/x264/
+
+Project: x265 
+License: GPL-2.0-or-later https://bitbucket.org/multicoreware/x265_git/src/master/COPYING
+Repo: https://bitbucket.org/multicoreware/x265_git/src/master/
+
+Project: pkg-config 
+License: GPL-2.0-or-later https://gitlab.freedesktop.org/pkg-config/pkg-config/-/blob/master/COPYING
+Repo: https://gitlab.freedesktop.org/pkg-config/pkg-config
+
+-----------------------------------------------------------------------------
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.
+
+
+
+-----------------------------------------------------------------------------
+Project: libvpx
+License:  BSD-3-Clause https://github.com/webmproject/libvpx/blob/master/LICENSE
+Repo: https://github.com/webmproject/libvpx/
+----------------------------------------------------------
+
+Copyright (c) 2010, The WebM Project authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+  * Neither the name of Google, nor the WebM Project, nor the names
+    of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written
+    permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+BSD 3-Clause Clear License
+
+----------------------------------------------------------
+Project: libaom-av1
+License: BSD-3-Clause https://aomedia.googlesource.com/aom/+/refs/heads/master/LICENSE
+Repo: https://aomedia.googlesource.com/aom/
+
+Also note: Allicance for Open Media Patent License 1.0
+-----------------------------------------------------------------------------
+
+The Clear BSD License
+
+Copyright (c) 2021, Alliance for Open Media
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted (subject to the limitations in the disclaimer below) provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+    Neither the name of the Alliance for Open Media nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+Alliance for Open Media Patent License 1.0
+
+    License Terms.
+
+    1.1. Patent License.
+
+    Subject to the terms and conditions of this License, each Licensor, on behalf of itself and successors in interest and assigns, grants Licensee a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) patent license to its Necessary Claims to make, use, sell, offer for sale, import or distribute any Implementation.
+
+    1.2. Conditions.
+
+    1.2.1. Availability.
+
+    As a condition to the grant of rights to Licensee to make, sell, offer for sale, import or distribute an Implementation under Section 1.1, Licensee must make its Necessary Claims available under this License, and must reproduce this License with any Implementation as follows:
+
+    a. For distribution in source code, by including this License in the root directory of the source code with its Implementation.
+
+    b. For distribution in any other form (including binary, object form, and/or hardware description code (e.g., HDL, RTL, Gate Level Netlist, GDSII, etc.)), by including this License in the documentation, legal notices, and/or other written materials provided with the Implementation.
+
+    1.2.2. Additional Conditions. This license is directly from Licensor to Licensee. Licensee acknowledges as a condition of benefiting from it that no rights from Licensor are received from suppliers, distributors, or otherwise in connection with this License.
+
+    1.3. Defensive Termination. If any Licensee, its Affiliates, or its agents initiates patent litigation or files, maintains, or voluntarily participates in a lawsuit against another entity or any person asserting that any Implementation infringes Necessary Claims, any patent licenses granted under this License directly to the Licensee are immediately terminated as of the date of the initiation of action unless 1) that suit was in response to a corresponding suit regarding an Implementation first brought against an initiating entity, or 2) that suit was brought to enforce the terms of this License (including intervention in a third-party action by a Licensee).
+
+    1.4. Disclaimers. The Reference Implementation and Specification are provided “AS IS” and without warranty. The entire risk as to implementing or otherwise using the Reference Implementation or Specification is assumed by the implementer and user. Licensor expressly disclaims any warranties (express, implied, or otherwise), including implied warranties of merchantability, non-infringement, fitness for a particular purpose, or title, related to the material. IN NO EVENT WILL LICENSOR BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS LICENSE, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+    Definitions.
+
+    2.1. Affiliate. “Affiliate” means an entity that directly or indirectly Controls, is Controlled by, or is under common Control of that party.
+
+    2.2. Control. “Control” means direct or indirect control of more than 50% of the voting power to elect directors of that corporation, or for any other entity, the power to direct management of such entity.
+
+    2.3. Decoder. “Decoder” means any decoder that conforms fully with all non-optional portions of the Specification.
+
+    2.4. Encoder. “Encoder” means any encoder that produces a bitstream that can be decoded by a Decoder only to the extent it produces such a bitstream.
+
+    2.5. Final Deliverable. “Final Deliverable” means the final version of a deliverable approved by the Alliance for Open Media as a Final Deliverable.
+
+    2.6. Implementation. “Implementation” means any implementation, including the Reference Implementation, that is an Encoder and/or a Decoder. An Implementation also includes components of an Implementation only to the extent they are used as part of an Implementation.
+
+    2.7. License. “License” means this license.
+
+    2.8. Licensee. “Licensee” means any person or entity who exercises patent rights granted under this License.
+
+    2.9. Licensor. “Licensor” means (i) any Licensee that makes, sells, offers for sale, imports or distributes any Implementation, or (ii) a person or entity that has a licensing obligation to the Implementation as a result of its membership and/or participation in the Alliance for Open Media working group that developed the Specification.
+
+    2.10. Necessary Claims. “Necessary Claims” means all claims of patents or patent applications, (a) that currently or at any time in the future, are owned or controlled by the Licensor, and (b) (i) would be an Essential Claim as defined by the W3C Policy as of February 5, 2004 (https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential) as if the Specification was a W3C Recommendation; or (ii) are infringed by the Reference Implementation.
+
+    2.11. Reference Implementation. “Reference Implementation” means an Encoder and/or Decoder released by the Alliance for Open Media as a Final Deliverable.
+
+    2.12. Specification. “Specification” means the specification designated by the Alliance for Open Media as a Final Deliverable for which this License was issued.
+
+
+--------------------------------------------------------------------
+Project: fontconfig
+License: MIT https://raw.githubusercontent.com/freedesktop/fontconfig/master/COPYING
+Repo: https://github.com/freedesktop/fontconfig
+
+--------------------------------------------------------------------
+fontconfig/COPYING
+
+Copyright © 2000,2001,2002,2003,2004,2006,2007 Keith Packard
+Copyright © 2005 Patrick Lam
+Copyright © 2007 Dwayne Bailey and Translate.org.za
+Copyright © 2009 Roozbeh Pournader
+Copyright © 2008,2009,2010,2011,2012,2013,2014,2015,2016,2017,2018,2019,2020 Red Hat, Inc.
+Copyright © 2008 Danilo Šegan
+Copyright © 2012 Google, Inc.
+
+
+Permission to use, copy, modify, distribute, and sell this software and its
+documentation for any purpose is hereby granted without fee, provided that
+the above copyright notice appear in all copies and that both that
+copyright notice and this permission notice appear in supporting
+documentation, and that the name of the author(s) not be used in
+advertising or publicity pertaining to distribution of the software without
+specific, written prior permission.  The authors make no
+representations about the suitability of this software for any purpose.  It
+is provided "as is" without express or implied warranty.
+
+THE AUTHOR(S) DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+
+--------------------------------------------------------------------------------
+fontconfig/fc-case/CaseFolding.txt
+
+© 2019 Unicode®, Inc.
+Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+For terms of use, see http://www.unicode.org/terms_of_use.html
+
+
+--------------------------------------------------------------------------------
+fontconfig/src/fcatomic.h
+
+/*
+ * Mutex operations.  Originally copied from HarfBuzz.
+ *
+ * Copyright © 2007  Chris Wilson
+ * Copyright © 2009,2010  Red Hat, Inc.
+ * Copyright © 2011,2012,2013  Google, Inc.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Contributor(s):
+ *	Chris Wilson <chris@chris-wilson.co.uk>
+ * Red Hat Author(s): Behdad Esfahbod
+ * Google Author(s): Behdad Esfahbod
+ */
+
+
+--------------------------------------------------------------------------------
+fontconfig/src/fcfoundry.h
+
+/*
+  Copyright © 2002-2003 by Juliusz Chroboczek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+
+--------------------------------------------------------------------------------
+fontconfig/src/fcmd5.h
+
+/*
+ * This code implements the MD5 message-digest algorithm.
+ * The algorithm is due to Ron Rivest.  This code was
+ * written by Colin Plumb in 1993, no copyright is claimed.
+ * This code is in the public domain; do with it what you wish.
+ *
+ * Equivalent code is available from RSA Data Security, Inc.
+ * This code has been tested against that, and is equivalent,
+ * except that you don't need to include two pages of legalese
+ * with every copy.
+ *
+ * To compute the message digest of a chunk of bytes, declare an
+ * MD5Context structure, pass it to MD5Init, call MD5Update as
+ * needed on buffers full of bytes, and then call MD5Final, which
+ * will fill a supplied 16-byte array with the digest.
+ */
+
+
+--------------------------------------------------------------------------------
+fontconfig/src/fcmutex.h
+
+/*
+ * Atomic int and pointer operations.  Originally copied from HarfBuzz.
+ *
+ * Copyright © 2007  Chris Wilson
+ * Copyright © 2009,2010  Red Hat, Inc.
+ * Copyright © 2011,2012,2013  Google, Inc.
+ *
+ * Permission is hereby granted, without written agreement and without
+ * license or royalty fees, to use, copy, modify, and distribute this
+ * software and its documentation for any purpose, provided that the
+ * above copyright notice and the following two paragraphs appear in
+ * all copies of this software.
+ *
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+ * IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ * Contributor(s):
+ *	Chris Wilson <chris@chris-wilson.co.uk>
+ * Red Hat Author(s): Behdad Esfahbod
+ * Google Author(s): Behdad Esfahbod
+ */
+
+
+--------------------------------------------------------------------------------
+fontconfig/src/ftglue.[ch]
+
+/* ftglue.c: Glue code for compiling the OpenType code from
+ *           FreeType 1 using only the public API of FreeType 2
+ *
+ * By David Turner, The FreeType Project (www.freetype.org)
+ *
+ * This code is explicitely put in the public domain
+ *
+ * ==========================================================================
+ *
+ * the OpenType parser codes was originally written as an extension to
+ * FreeType 1.x. As such, its source code was embedded within the library,
+ * and used many internal FreeType functions to deal with memory and
+ * stream i/o.
+ *
+ * When it was 'salvaged' for Pango and Qt, the code was "ported" to FreeType 2,
+ * which basically means that some macro tricks were performed in order to
+ * directly access FT2 _internal_ functions.
+ *
+ * these functions were never part of FT2 public API, and _did_ change between
+ * various releases. This created chaos for many users: when they upgraded the
+ * FreeType library on their system, they couldn't run Gnome anymore since
+ * Pango refused to link.
+ *
+ * Very fortunately, it's possible to completely avoid this problem because
+ * the FT_StreamRec and FT_MemoryRec structure types, which describe how
+ * memory and stream implementations interface with the rest of the font
+ * library, have always been part of the public API, and never changed.
+ *
+ * What we do thus is re-implement, within the OpenType parser, the few
+ * functions that depend on them. This only adds one or two kilobytes of
+ * code, and ensures that the parser can work with _any_ version
+ * of FreeType installed on your system. How sweet... !
+ *
+ * Note that we assume that Pango doesn't use any other internal functions
+ * from FreeType. It used to in old versions, but this should no longer
+ * be the case. (crossing my fingers).
+ *
+ *  - David Turner
+ *  - The FreeType Project  (www.freetype.org)
+ *
+ * PS: This "glue" code is explicitely put in the public domain
+ */
+
+--------------------------------------------------------------------
+Project: freetype
+License: FTL https://gitlab.freedesktop.org/freetype/freetype/-/raw/master/docs/FTL.TXT 
+Repo: https://gitlab.freedesktop.org/freetype/freetype
+--------------------------------------------------------------------
+
+  The FreeType Project LICENSE
+                    ----------------------------
+
+                            2006-Jan-27
+
+                    Copyright 1996-2002, 2006 by
+          David Turner, Robert Wilhelm, and Werner Lemberg
+
+
+
+Introduction
+============
+
+  The FreeType  Project is distributed in  several archive packages;
+  some of them may contain, in addition to the FreeType font engine,
+  various tools and  contributions which rely on, or  relate to, the
+  FreeType Project.
+
+  This  license applies  to all  files found  in such  packages, and
+  which do not  fall under their own explicit  license.  The license
+  affects  thus  the  FreeType   font  engine,  the  test  programs,
+  documentation and makefiles, at the very least.
+
+  This  license   was  inspired  by  the  BSD,   Artistic,  and  IJG
+  (Independent JPEG  Group) licenses, which  all encourage inclusion
+  and  use of  free  software in  commercial  and freeware  products
+  alike.  As a consequence, its main points are that:
+
+    o We don't promise that this software works. However, we will be
+      interested in any kind of bug reports. (`as is' distribution)
+
+    o You can  use this software for whatever you  want, in parts or
+      full form, without having to pay us. (`royalty-free' usage)
+
+    o You may not pretend that  you wrote this software.  If you use
+      it, or  only parts of it,  in a program,  you must acknowledge
+      somewhere  in  your  documentation  that  you  have  used  the
+      FreeType code. (`credits')
+
+  We  specifically  permit  and  encourage  the  inclusion  of  this
+  software, with  or without modifications,  in commercial products.
+  We  disclaim  all warranties  covering  The  FreeType Project  and
+  assume no liability related to The FreeType Project.
+
+
+  Finally,  many  people  asked  us  for  a  preferred  form  for  a
+  credit/disclaimer to use in compliance with this license.  We thus
+  encourage you to use the following text:
+
+   """
+    Portions of this software are copyright © <year> The FreeType
+    Project (www.freetype.org).  All rights reserved.
+   """
+
+  Please replace <year> with the value from the FreeType version you
+  actually use.
+
+
+Legal Terms
+===========
+
+0. Definitions
+--------------
+
+  Throughout this license,  the terms `package', `FreeType Project',
+  and  `FreeType  archive' refer  to  the  set  of files  originally
+  distributed  by the  authors  (David Turner,  Robert Wilhelm,  and
+  Werner Lemberg) as the `FreeType Project', be they named as alpha,
+  beta or final release.
+
+  `You' refers to  the licensee, or person using  the project, where
+  `using' is a generic term including compiling the project's source
+  code as  well as linking it  to form a  `program' or `executable'.
+  This  program is  referred to  as  `a program  using the  FreeType
+  engine'.
+
+  This  license applies  to all  files distributed  in  the original
+  FreeType  Project,   including  all  source   code,  binaries  and
+  documentation,  unless  otherwise  stated   in  the  file  in  its
+  original, unmodified form as  distributed in the original archive.
+  If you are  unsure whether or not a particular  file is covered by
+  this license, you must contact us to verify this.
+
+  The FreeType  Project is copyright (C) 1996-2000  by David Turner,
+  Robert Wilhelm, and Werner Lemberg.  All rights reserved except as
+  specified below.
+
+1. No Warranty
+--------------
+
+  THE FREETYPE PROJECT  IS PROVIDED `AS IS' WITHOUT  WARRANTY OF ANY
+  KIND, EITHER  EXPRESS OR IMPLIED,  INCLUDING, BUT NOT  LIMITED TO,
+  WARRANTIES  OF  MERCHANTABILITY   AND  FITNESS  FOR  A  PARTICULAR
+  PURPOSE.  IN NO EVENT WILL ANY OF THE AUTHORS OR COPYRIGHT HOLDERS
+  BE LIABLE  FOR ANY DAMAGES CAUSED  BY THE USE OR  THE INABILITY TO
+  USE, OF THE FREETYPE PROJECT.
+
+2. Redistribution
+-----------------
+
+  This  license  grants  a  worldwide, royalty-free,  perpetual  and
+  irrevocable right  and license to use,  execute, perform, compile,
+  display,  copy,   create  derivative  works   of,  distribute  and
+  sublicense the  FreeType Project (in  both source and  object code
+  forms)  and  derivative works  thereof  for  any  purpose; and  to
+  authorize others  to exercise  some or all  of the  rights granted
+  herein, subject to the following conditions:
+
+    o Redistribution of  source code  must retain this  license file
+      (`FTL.TXT') unaltered; any  additions, deletions or changes to
+      the original  files must be clearly  indicated in accompanying
+      documentation.   The  copyright   notices  of  the  unaltered,
+      original  files must  be  preserved in  all  copies of  source
+      files.
+
+    o Redistribution in binary form must provide a  disclaimer  that
+      states  that  the software is based in part of the work of the
+      FreeType Team,  in  the  distribution  documentation.  We also
+      encourage you to put an URL to the FreeType web page  in  your
+      documentation, though this isn't mandatory.
+
+  These conditions  apply to any  software derived from or  based on
+  the FreeType Project,  not just the unmodified files.   If you use
+  our work, you  must acknowledge us.  However, no  fee need be paid
+  to us.
+
+3. Advertising
+--------------
+
+  Neither the  FreeType authors and  contributors nor you  shall use
+  the name of the  other for commercial, advertising, or promotional
+  purposes without specific prior written permission.
+
+  We suggest,  but do not require, that  you use one or  more of the
+  following phrases to refer  to this software in your documentation
+  or advertising  materials: `FreeType Project',  `FreeType Engine',
+  `FreeType library', or `FreeType Distribution'.
+
+  As  you have  not signed  this license,  you are  not  required to
+  accept  it.   However,  as  the FreeType  Project  is  copyrighted
+  material, only  this license, or  another one contracted  with the
+  authors, grants you  the right to use, distribute,  and modify it.
+  Therefore,  by  using,  distributing,  or modifying  the  FreeType
+  Project, you indicate that you understand and accept all the terms
+  of this license.
+
+4. Contacts
+-----------
+
+  There are two mailing lists related to FreeType:
+
+    o freetype@nongnu.org
+
+      Discusses general use and applications of FreeType, as well as
+      future and  wanted additions to the  library and distribution.
+      If  you are looking  for support,  start in  this list  if you
+      haven't found anything to help you in the documentation.
+
+    o freetype-devel@nongnu.org
+
+      Discusses bugs,  as well  as engine internals,  design issues,
+      specific licenses, porting, etc.
+
+  Our home page can be found at
+
+    https://www.freetype.org
+
+
+--- end of FTL.TXT ---
+  
+----------------------------------
+Project: lame
+License: LGPL-2.0 https://sourceforge.net/p/lame/svn/HEAD/tree/tags/RELEASE__3_100/lame/COPYING
+Repo: https://sourceforge.net/p/lame/svn/HEAD/tree/ 
+---------------------------------
+
+
+                  GNU LIBRARY GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1991 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the library GPL.  It is
+ numbered 2 because it goes with version 2 of the ordinary GPL.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Library General Public License, applies to some
+specially designated Free Software Foundation software, and to any
+other libraries whose authors decide to use it.  You can use it for
+your libraries, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if
+you distribute copies of the library, or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link a program with the library, you must provide
+complete object files to the recipients so that they can relink them
+with the library, after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  Our method of protecting your rights has two steps: (1) copyright
+the library, and (2) offer you this license which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  Also, for each distributor's protection, we want to make certain
+that everyone understands that there is no warranty for this free
+library.  If the library is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original
+version, so that any problems introduced by others will not reflect on
+the original authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that companies distributing free
+software will individually obtain patent licenses, thus in effect
+transforming the program into proprietary software.  To prevent this,
+we have made it clear that any patent must be licensed for everyone's
+free use or not licensed at all.
+
+  Most GNU software, including some libraries, is covered by the ordinary
+GNU General Public License, which was designed for utility programs.  This
+license, the GNU Library General Public License, applies to certain
+designated libraries.  This license is quite different from the ordinary
+one; be sure to read it in full, and don't assume that anything in it is
+the same as in the ordinary license.
+
+  The reason we have a separate public license for some libraries is that
+they blur the distinction we usually make between modifying or adding to a
+program and simply using it.  Linking a program with a library, without
+changing the library, is in some sense simply using the library, and is
+analogous to running a utility program or application program.  However, in
+a textual and legal sense, the linked executable is a combined work, a
+derivative of the original library, and the ordinary General Public License
+treats it as such.
+
+  Because of this blurred distinction, using the ordinary General
+Public License for libraries did not effectively promote software
+sharing, because most developers did not use the libraries.  We
+concluded that weaker conditions might promote sharing better.
+
+  However, unrestricted linking of non-free programs would deprive the
+users of those programs of all benefit from the free status of the
+libraries themselves.  This Library General Public License is intended to
+permit developers of non-free programs to use free libraries, while
+preserving your freedom as a user of such programs to change the free
+libraries that are incorporated in them.  (We have not seen how to achieve
+this as regards changes in header files, but we have achieved it as regards
+changes in the actual functions of the Library.)  The hope is that this
+will lead to faster development of free libraries.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, while the latter only
+works together with the library.
+
+  Note that it is possible for a library to be covered by the ordinary
+General Public License rather than by this special one.
+
+                  GNU LIBRARY GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library which
+contains a notice placed by the copyright holder or other authorized
+party saying it may be distributed under the terms of this Library
+General Public License (also called "this License").  Each licensee is
+addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+  
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also compile or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    c) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    d) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the source code distributed need not include anything that is normally
+distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Library General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Library General Public License for more details.
+
+    You should have received a copy of the GNU Library General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!
+
+
+---------------------------------------
+Projec: libass
+License: ISC https://raw.githubusercontent.com/libass/libass/master/COPYING
+Repo: https://github.com/libass/libass
+---------------------------------------
+
+ISC License
+
+Copyright (C) 2006-2016 libass contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+-----------------------------------------------------------------------------
+Project: ffmpeg-filter-proxy
+License: LGPL-2.1-or-later https://raw.githubusercontent.com/svt/ffmpeg-filter-proxy/master/LICENSE
+Repo: https://github.com/svt/ffmpeg-filter-proxy
+
+Project: libssh
+License: LGPL-2.1 https://git.libssh.org/projects/libssh.git/tree/COPYING
+Repo: https://git.libssh.org/projects/libssh.git/tree/
+
+Project: libsxor
+License: LGPL-2.1 https://github.com/chirlu/soxr/blob/master/COPYING.LGPL
+Repo: https://github.com/chirlu/soxr
+---------------------------------------
+
+
+  GNU LESSER GENERAL PUBLIC LICENSE
+		       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+		  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+			    NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!
+
+
+-------------------------------
+Project: libvmaf
+License: BSD+Patent https://raw.githubusercontent.com/Netflix/vmaf/master/LICENSE 
+Repo: https://github.com/Netflix/vmaf/tree/master/libvmaf
+-------------------------------
+
+LICENSE - BSD+Patent
+SPDX short identifier: BSD-2-Clause-Patent
+
+Note: This license is designed to provide: a) a simple permissive license; b) that is compatible with the GNU General
+Public License (GPL), version 2; and c) which also has an express patent grant included.
+
+Copyright (c) 2020 Netflix, Inc.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided with the distribution.
+
+Subject to the terms and conditions of this license, each copyright holder and contributor hereby grants to those
+receiving rights under this license a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except
+for failure to satisfy the conditions of this license) patent license to make, have made, use, offer to sell, sell,
+import, and otherwise transfer this software, where such license applies only to those patent claims, already acquired
+or hereafter acquired, licensable by such copyright holder or contributor that are necessarily infringed by:
+
+(a) their Contribution(s) (the licensed copyrights of copyright holders and non-copyrightable additions of contributors,
+in source or binary form) alone; or
+
+(b) combination of their Contribution(s) with the work of authorship to which such Contribution(s) was added by such
+copyright holder or contributor, if, at the time the Contribution is added, such addition causes such combination to be
+necessarily infringed. The patent license shall not apply to any other combinations which include the Contribution.
+
+Except as expressly stated above, no rights or licenses from any copyright holder or contributor is granted under this
+license, whether expressly, by implication, estoppel or otherwise.
+
+DISCLAIMER
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+--------------------------------------
+Project: vorbis
+License: BSD-3-Clause https://gitlab.xiph.org/xiph/vorbis/-/blob/master/COPYING
+Repo: https://gitlab.xiph.org/xiph/vorbis
+--------------------------------------------------
+
+Copyright (c) 2002-2020 Xiph.org Foundation
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+- Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of the Xiph.org Foundation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  
+
+---------------------------
+Project: FFmpeg filter proxy filters
+License: Apache-2.0 https://github.com/svt/ffmpeg-filter-proxy-filters/blob/master/LICENSE
+Repo: https://github.com/SVT/ffmpeg-filter-proxy-filters
+
+Project: openssl (3) 
+License: Apache-2.0 https://raw.githubusercontent.com/openssl/openssl/master/LICENSE.txt
+Repo: https://github.com/openssl/openssl
+---------------------------
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+
+------------------------------------------- 
+Project: bzip2
+License: 
+Repo: 
+------------------------------------------------
+
+
+This program, "bzip2", the associated library "libbzip2", and all
+documentation, are copyright (C) 1996-2019 Julian R Seward.  All
+rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. The origin of this software must not be misrepresented; you must 
+   not claim that you wrote the original software.  If you use this 
+   software in a product, an acknowledgment in the product 
+   documentation would be appreciated but is not required.
+
+3. Altered source versions must be plainly marked as such, and must
+   not be misrepresented as being the original software.
+
+4. The name of the author may not be used to endorse or promote 
+   products derived from this software without specific prior written 
+   permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Julian Seward, jseward@acm.org
+bzip2/libbzip2 version 1.0.8 of 13 July 2019
+
+------------------------------------------- 
+Project: zlib
+License:  Zlib https://raw.githubusercontent.com/madler/zlib/master/README
+Repo: https://github.com/madler/zlib 
+
+/* zlib.h -- interface of the 'zlib' general purpose compression library
+  version 1.2.11, January 15th, 2017
+
+  Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Jean-loup Gailly        Mark Adler
+  jloup@gzip.org          madler@alumni.caltech.edu
+
+*/
+   
+
+------------------------------------------- 
+Project: sdl2
+License: Zlib https://raw.githubusercontent.com/libsdl-org/SDL/main/LICENSE.txt 
+Repo: https://github.com/libsdl-org/SDL 
+------------------------------------------------
+ 
+Copyright (C) 1997-2021 Sam Lantinga <slouken@libsdl.org>
+  
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+  
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required. 
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+
+---------------------------------------------------------------
+Project: libXv
+License: MIT https://gitlab.freedesktop.org/xorg/lib/libxv/-/blob/master/COPYING
+Repo:  https://gitlab.freedesktop.org/xorg/lib/libxv
+-----------------------------------------------------------------
+
+Copyright 1991 by Digital Equipment Corporation, Maynard, Massachusetts,
+and the Massachusetts Institute of Technology, Cambridge, Massachusetts.
+
+                        All Rights Reserved
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appear in all copies and that
+both that copyright notice and this permission notice appear in
+supporting documentation, and that the names of Digital or MIT not be
+used in advertising or publicity pertaining to distribution of the
+software without specific, written prior permission.
+
+DIGITAL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
+ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT SHALL
+DIGITAL BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR
+ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+SOFTWARE.
+
+______________________________________________________________________________
+
+Copyright 2005 Red Hat, Inc.
+
+Permission to use, copy, modify, distribute, and sell this software and its
+documentation for any purpose is hereby granted without fee, provided that
+the above copyright notice appear in all copies and that both that
+copyright notice and this permission notice appear in supporting
+documentation, and that the name of Red Hat not be used in
+advertising or publicity pertaining to distribution of the software without
+specific, written prior permission.  Red Hat makes no
+representations about the suitability of this software for any purpose.  It
+is provided "as is" without express or implied warranty.
+
+RED HAT DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+EVENT SHALL RED HAT BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+
+NOTE: The current FDK-AAC licensen is not GPLxx compatible, don't distrubute a build with this and GPL libraries in
+---------------------------------------------------------------------------
+Project: FraunHofer FDK AAC
+License: Frauhofer FDK AAC License  https://raw.githubusercontent.com/mstorsjo/fdk-aac/master/NOTICE
+Repo: https://github.com/mstorsjo/fdk-aac
+---------------------------------------------------
+
+
+Software License for The Fraunhofer FDK AAC Codec Library for Android
+
+© Copyright  1995 - 2018 Fraunhofer-Gesellschaft zur Förderung der angewandten
+Forschung e.V. All rights reserved.
+
+ 1.    INTRODUCTION
+The Fraunhofer FDK AAC Codec Library for Android ("FDK AAC Codec") is software
+that implements the MPEG Advanced Audio Coding ("AAC") encoding and decoding
+scheme for digital audio. This FDK AAC Codec software is intended to be used on
+a wide variety of Android devices.
+
+AAC's HE-AAC and HE-AAC v2 versions are regarded as today's most efficient
+general perceptual audio codecs. AAC-ELD is considered the best-performing
+full-bandwidth communications codec by independent studies and is widely
+deployed. AAC has been standardized by ISO and IEC as part of the MPEG
+specifications.
+
+Patent licenses for necessary patent claims for the FDK AAC Codec (including
+those of Fraunhofer) may be obtained through Via Licensing
+(www.vialicensing.com) or through the respective patent owners individually for
+the purpose of encoding or decoding bit streams in products that are compliant
+with the ISO/IEC MPEG audio standards. Please note that most manufacturers of
+Android devices already license these patent claims through Via Licensing or
+directly from the patent owners, and therefore FDK AAC Codec software may
+already be covered under those patent licenses when it is used for those
+licensed purposes only.
+
+Commercially-licensed AAC software libraries, including floating-point versions
+with enhanced sound quality, are also available from Fraunhofer. Users are
+encouraged to check the Fraunhofer website for additional applications
+information and documentation.
+
+2.    COPYRIGHT LICENSE
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted without payment of copyright license fees provided that you
+satisfy the following conditions:
+
+You must retain the complete text of this software license in redistributions of
+the FDK AAC Codec or your modifications thereto in source code form.
+
+You must retain the complete text of this software license in the documentation
+and/or other materials provided with redistributions of the FDK AAC Codec or
+your modifications thereto in binary form. You must make available free of
+charge copies of the complete source code of the FDK AAC Codec and your
+modifications thereto to recipients of copies in binary form.
+
+The name of Fraunhofer may not be used to endorse or promote products derived
+from this library without prior written permission.
+
+You may not charge copyright license fees for anyone to use, copy or distribute
+the FDK AAC Codec software or your modifications thereto.
+
+Your modified versions of the FDK AAC Codec must carry prominent notices stating
+that you changed the software and the date of any change. For modified versions
+of the FDK AAC Codec, the term "Fraunhofer FDK AAC Codec Library for Android"
+must be replaced by the term "Third-Party Modified Version of the Fraunhofer FDK
+AAC Codec Library for Android."
+
+3.    NO PATENT LICENSE
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PATENT CLAIMS, including without
+limitation the patents of Fraunhofer, ARE GRANTED BY THIS SOFTWARE LICENSE.
+Fraunhofer provides no warranty of patent non-infringement with respect to this
+software.
+
+You may use this FDK AAC Codec software or modifications thereto only for
+purposes that are authorized by appropriate patent licenses.
+
+4.    DISCLAIMER
+
+This FDK AAC Codec software is provided by Fraunhofer on behalf of the copyright
+holders and contributors "AS IS" and WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES,
+including but not limited to the implied warranties of merchantability and
+fitness for a particular purpose. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE for any direct, indirect, incidental, special, exemplary,
+or consequential damages, including but not limited to procurement of substitute
+goods or services; loss of use, data, or profits, or business interruption,
+however caused and on any theory of liability, whether in contract, strict
+liability, or tort (including negligence), arising in any way out of the use of
+this software, even if advised of the possibility of such damage.
+
+5.    CONTACT INFORMATION
+
+Fraunhofer Institute for Integrated Circuits IIS
+Attention: Audio and Multimedia Departments - FDK AAC LL
+Am Wolfsmantel 33
+91058 Erlangen, Germany
+
+www.iis.fraunhofer.de/amm
+amm-info@iis.fraunhofer.de
+

--- a/docker/misc/motd.dist.txt
+++ b/docker/misc/motd.dist.txt
@@ -1,0 +1,32 @@
+
+===================================================================
+= AVTools Docker Image                                            =
+=								  =
+= Only intended for *development tests*, *not* for production use =
+===================================================================
+
+This Docker container includes, among others, Free and Open Source 
+software (FOSS) that was developed by third parties. In particular, the 
+applicable licenses include the GNU General Public License and GNU 
+Lesser General Public License, for which the following disclaimer of
+warranty in favor of the holders of rights applies:
+
+This program is distributed in the hope that it will be useful, but 
+WITHOUT ANY WARRANTY; without even the implied warranty of 
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General 
+Public License for more details. 
+
+For all other FOSS components, see the warranty disclaimers in favor of 
+the holders of rights in the respective license texts.
+
+The source code, license texts of installed software packages are archived in
+the *corresponding source image* from the AVTools repo, where you will find:
+
+/buster-src_x.tgz - source and licenses for the packages in the OSADL base image layer 
+/source/brew-src_x_tar.xz - source and licenses for the packages used the brew build image layer 
+/source/apt-src_x.tar.xz -  source and licenses for the packages used in the apt layer
+
+However, in this distribution image you will also find a:
+/LICENSE_THIRD_PARTY.txt - license information about the packages used for creating the FFmpeg binary.
+
+

--- a/docker/misc/motd.dist.txt
+++ b/docker/misc/motd.dist.txt
@@ -5,26 +5,29 @@
 = Only intended for *development tests*, *not* for production use =
 ===================================================================
 
-This Docker container includes, among others, Free and Open Source 
-software (FOSS) that was developed by third parties. In particular, the 
-applicable licenses include the GNU General Public License and GNU 
+This container includes, among others, Free and Open Source software
+(FOSS) that was developed by third parties. In particular, the
+applicable licenses include the GNU General Public License and GNU
 Lesser General Public License, for which the following disclaimer of
 warranty in favor of the holders of rights applies:
 
-This program is distributed in the hope that it will be useful, but 
-WITHOUT ANY WARRANTY; without even the implied warranty of 
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General 
-Public License for more details. 
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+Public License for more details.
 
-For all other FOSS components, see the warranty disclaimers in favor of 
+For all other FOSS components, see the warranty disclaimers in favor of
 the holders of rights in the respective license texts.
 
-The source code, license texts of installed software packages are archived in
+The source code, license texts and other legal information including
+build instructions of all installed software packages are archived in
+the root directory of the container in bullseye-[arch]-[date]-src.tgz.
+
+The source code, license texts of added software packages are archived in
 the *corresponding source image* from the AVTools repo, where you will find:
 
-/buster-src_x.tgz - source and licenses for the packages in the OSADL base image layer 
-/source/brew-src_x_tar.xz - source and licenses for the packages used the brew build image layer 
-/source/apt-src_x.tar.xz -  source and licenses for the packages used in the apt layer
+/source/brew-src_[date]_tar.xz - source and licenses for the packages used the brew build image layer 
+/source/apt-src_[date].tar.xz -  source and licenses for the packages used in the apt layer
 
 However, in this distribution image you will also find a:
 /LICENSE_THIRD_PARTY.txt - license information about the packages used for creating the FFmpeg binary.

--- a/docker/misc/motd.source.txt
+++ b/docker/misc/motd.source.txt
@@ -6,23 +6,26 @@
 = the Distribution image. For better compliance.                  =
 ===================================================================
 
-This Docker container includes, among others, Free and Open Source 
-software (FOSS) that was developed by third parties. In particular, the 
-applicable licenses include the GNU General Public License and GNU 
-Lesser General Public License, for which the following disclaimer of 
-warranty in favor of the holders of rights applies: 
+This container includes, among others, Free and Open Source software
+(FOSS) that was developed by third parties. In particular, the
+applicable licenses include the GNU General Public License and GNU
+Lesser General Public License, for which the following disclaimer of
+warranty in favor of the holders of rights applies:
 
-This program is distributed in the hope that it will be useful, but 
-WITHOUT ANY WARRANTY; without even the implied warranty of 
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
 Public License for more details.
 
 For all other FOSS components, see the warranty disclaimers in favor of
 the holders of rights in the respective license texts.
 
-The source code, license texts of installed software packages are archived in
-this *corresponding source image*:
+The source code, license texts and other legal information including
+build instructions of all installed software packages are archived in
+the root directory of the container in bullseye-[arch]-[date]-src.tgz.
 
-/buster-src_x.tgz - source and licenses for the packages in the OSADL base image layer 
+The source code, license texts of added installed software packages are archived in
+this *corresponding source image* of the AVTools dist:
+
 /source/brew-src_x_tar.xz - source and licenses for the packages used the brew build image layer 
 /source/apt-src_x.tar.xz -  source and licenses for the packages used in the apt layer

--- a/docker/misc/motd.source.txt
+++ b/docker/misc/motd.source.txt
@@ -1,0 +1,28 @@
+
+===================================================================
+= AVTools Docker container Source Image                           =
+=								  =
+= Only intended as a source, license companion to                 =
+= the Distribution image. For better compliance.                  =
+===================================================================
+
+This Docker container includes, among others, Free and Open Source 
+software (FOSS) that was developed by third parties. In particular, the 
+applicable licenses include the GNU General Public License and GNU 
+Lesser General Public License, for which the following disclaimer of 
+warranty in favor of the holders of rights applies: 
+
+This program is distributed in the hope that it will be useful, but 
+WITHOUT ANY WARRANTY; without even the implied warranty of 
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+Public License for more details.
+
+For all other FOSS components, see the warranty disclaimers in favor of
+the holders of rights in the respective license texts.
+
+The source code, license texts of installed software packages are archived in
+this *corresponding source image*:
+
+/buster-src_x.tgz - source and licenses for the packages in the OSADL base image layer 
+/source/brew-src_x_tar.xz - source and licenses for the packages used the brew build image layer 
+/source/apt-src_x.tar.xz -  source and licenses for the packages used in the apt layer


### PR DESCRIPTION
Build and publish images with GitHub Actions

## Description

This PR adds a GitHub action to publish a set of Docker images upon commits to master/main.
It builds 3 sets of images - a dist, a non-dist, a source image. *The non-dist is not intented for distrubution*, and must be *private* as it contains a non gpl-compatible component. The source image is just a companion, intended to improve legal compliance (i.e potential distrubtion requests)

All images are currently built for the amd64 platform
All images are currently built on the OSADL Debian Base image, as it offers a legal compliance base.



The images are built in order - non-dist, dist, source, so long before the build is done one can start using the non-dist, dist images. Note: The source image takes "a lot of time" to finish, due to fetching sources, packaging them etc.

Note: the non-dist is currently commented out.

The motivation for this was two-fold: 

- In the end to make it easier to further run applications that uses avtools as a base, without having to install and build the whole chain.
- It was also an internal project in how to find a set of best practices for offering Docker Images in general, in the future.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The images was run on amd64 platform, together with the encore application. Some manual random tests was run locally on the ffmpeg, mediainfo apps. The non-dist image was tested as a base for running encore internal and with the system tests.
Note: the arm64 build had problems,  so for now we dont build for that.

## Checklist:

- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the Developer Certificate of Origin (see https://github.com/svt/open-source-project-template/blob/master/docs/CONTRIBUTING.adoc[docs/CONTRIBUTING]).
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)

