### PR TITLE
build: add jre 11 variant

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,6 +10,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME_DIST: avtools-osadl-debian
+  IMAGE_NAME_JRE_DIST: avtools-osadl-jre-debian
   IMAGE_NAME_SOURCE: avtools-osadl-debian-source
   IMAGE_NAME: avtools-osadl-debian-non-dist
 
@@ -91,8 +92,8 @@ jobs:
           tags: |
             type=raw,value={{branch}},priority=1,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
             type=ref,event=tag,priority=2
-            type=raw,value=${{ env.IMAGE_NAME }}-{{branch}}-{{date 'YYYYMMDD'}}-{{sha}},priority=31,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=${{ env.IMAGE_NAME }}-{{tag}}-{{date 'YYYYMMDD'}}-{{sha}},priority=32, enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ env.IMAGE_NAME_DIST }}-{{branch}}-{{date 'YYYYMMDD'}}-{{sha}},priority=31,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ env.IMAGE_NAME_DIST }}-{{tag}}-{{date 'YYYYMMDD'}}-{{sha}},priority=32, enable=${{ startsWith(github.ref, 'refs/tags/v') }}
       
       - name: Build and push distribution image
         uses: docker/build-push-action@v2
@@ -108,6 +109,36 @@ jobs:
                   FFMPEG_BREW_OPTIONS=--without-fdk-aac
           labels: ${{ steps.metadist.outputs.labels }}
           target: distribution
+      
+      - name: Extract metadata (tags, labels) for distribution image with jre
+        id: metadistjre
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_JRE_DIST }}
+          flavor: |
+            latest=true
+          tags: |
+            type=raw,value={{branch}},priority=1,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
+            type=ref,event=tag,priority=2
+            type=raw,value=${{ env.IMAGE_NAME_JRE_DIST }}-{{branch}}-{{date 'YYYYMMDD'}}-{{sha}},priority=31,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ env.IMAGE_NAME_JRE_DIST }}-{{tag}}-{{date 'YYYYMMDD'}}-{{sha}},priority=32, enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+      
+      
+      - name: Build and push distribution image with jre
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/Dockerfile.osadl.debian
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.metadistjre.outputs.tags }}
+          build-args: |
+                  WITH_JRE=openjdk-11-jre-headless
+                  FFMPEG_BREW_OPTIONS=--without-fdk-aac
+          labels: ${{ steps.metadistjre.outputs.labels }}
+          target: distribution
 
       - name: Extract metadata (tags, labels) for source image
         id: metasource
@@ -119,8 +150,8 @@ jobs:
           tags: |
             type=raw,value={{branch}},priority=1,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
             type=ref,event=tag,priority=2
-            type=raw,value=${{ env.IMAGE_NAME }}-{{branch}}-{{date 'YYYYMMDD'}}-{{sha}},priority=31,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=${{ env.IMAGE_NAME }}-{{tag}}-{{date 'YYYYMMDD'}}-{{sha}},priority=32, enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ env.IMAGE_NAME_SOURCE }}-{{branch}}-{{date 'YYYYMMDD'}}-{{sha}},priority=31,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ env.IMAGE_NAME_SOURCE }}-{{tag}}-{{date 'YYYYMMDD'}}-{{sha}},priority=32, enable=${{ startsWith(github.ref, 'refs/tags/v') }}
       
       - name: Build and push source image
         uses: docker/build-push-action@v2

--- a/docker/Dockerfile.osadl.debian
+++ b/docker/Dockerfile.osadl.debian
@@ -30,6 +30,7 @@ ARG APT_BUILD_DEPS="autoconf \
 
 ARG DOCKER_BASE=osadl/debian-docker-base-image:bullseye-amd64-211011
 ARG REPO_OWNER=svt
+ARG WITH_JRE
 
 #General dependency image - to simplify caching.
 FROM ${DOCKER_BASE} as dependencies
@@ -74,11 +75,11 @@ FROM buildimage as trimimage
 
 RUN rm -rf /home/linuxbrew/.linuxbrew/Homebrew 
 
-
 #distribution image
 FROM ${DOCKER_BASE} as distribution
 
 ARG REPO_OWNER
+ARG WITH_JRE
 
 LABEL org.opencontainers.image.url="https://github.com/$REPO_OWNER/homebrew-avtools"
 LABEL org.opencontainers.image.source="https://github.com/$REPO_OWNER/homebrew-avtools"
@@ -86,10 +87,13 @@ LABEL org.opencontainers.image.title="avtools-osadl-debian-distribution"
  
 # brew issue, the avtools-tap formulas for ffmpeg and mediainfo uses some host system libraries instead of 100% brew -> slight host dependency instead of brew dep. If brew updates the glibc version this most likely be discarded, at least most parts of it. 
 
-RUN useradd -ms /bin/bash avtools && \
-    apt-get update --allow-releaseinfo-change && apt upgrade && \ 
-    apt-get install -yq --no-install-recommends libc6 && \
+RUN apt-get update --allow-releaseinfo-change && apt upgrade && \ 
+    apt-get install -yq --no-install-recommends libc6 sudo ${WITH_JRE}  && \
+    adduser --disabled-password --gecos '' avtools && \
+    adduser avtools sudo && \ 
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
     apt-get clean && apt-get autoremove
+
 
 COPY docker/misc/motd.dist.txt /etc/motd
 COPY docker/misc/LICENSE-THIRD-PARTY.txt /


### PR DESCRIPTION
Signed-off-by: Josef Andersson <josef.andersson@svt.se>

## Description

During run of the publish GH-action, an dist image with jre 11 will be added. This variant was added to simplify running encore etc. The avtools user was also added to the sudo group.
Note: In the future, it is possibly that these docker packages will be moved to a general Docker GHCR repo instead of directly under avtools

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested with encore, using this as a base image

## Checklist:

- [xI confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the Developer Certificate of Origin (see https://github.com/svt/open-source-project-template/blob/master/docs/CONTRIBUTING.adoc[docs/CONTRIBUTING]).
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)

